### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ study.optimize(n_trials: 100) do |trial|
   accuracy = report[:test_score].sum / splitter.n_splits
   1.0 - accuracy
 end
-p study.best_trial
+
+#puts PyCall.tuple(study.best_trial)
+puts study.best_params
 ```
 
 ## License

--- a/example/rumale-simple.rb
+++ b/example/rumale-simple.rb
@@ -9,7 +9,7 @@ x = iris.to_narray(:sepal_length,
                    :sepal_width,
                    :petal_length,
                    :petal_width)
-y = Numo::NArray[*iris.label_encode(:label)]
+y = Numo::NArray.cast(iris.label_encode(:label))
 
 study = Optuna::Study.new
 study.optimize(n_trials: 100) do |trial|
@@ -30,4 +30,6 @@ study.optimize(n_trials: 100) do |trial|
   accuracy = report[:test_score].sum / splitter.n_splits
   1.0 - accuracy
 end
-p study.best_trial
+
+#puts PyCall.tuple(study.best_trial)
+puts study.best_params


### PR DESCRIPTION
Fix two errors.

1. `p` -> `puts`
Terminal freezes after using `p`. I don't know why. Maybe some broken characters were passed to the terminal output.

2. `study.best_trial` -> `study.best_params`
`study.best_trial` actually return a FrozenTrial class object. But PyCall mistake it for a Tuple object. As a result, it causes an error. In order to prevent it, we have to convert it from `FrozenTrial` to `Tuple` by calling `PyCall.tuple()`. But showing how to handle Python tuple in PyCall is not the main purpose for the rumale-simple example, I replaced it to `best_params`. 